### PR TITLE
typo in rules/xla/concat/Main.hs rule04

### DIFF
--- a/rules/xla/concat/Main.hs
+++ b/rules/xla/concat/Main.hs
@@ -56,7 +56,7 @@ rule04 :: forall a. AnyDTypeRule a
 rule04 _ = do
   [rclass0, rclass1] <- newRClasses ["rclass0", "rclass1"]
   [rc0Size, rc0Start, rc0End, rc0Stride] <-
-    newMaps ["rc0Start", "rc0Start", "rc0End", "rc0Stride"] rclass0
+    newMaps ["rc0Size", "rc0Start", "rc0End", "rc0Stride"] rclass0
   [rc1Size, rc1Start1, rc1End1, rc1Start2, rc1End2, rc1Stride] <-
     newMaps ["rc1Size", "rc1Start1", "rc1End1", "rc1Start2", "rc1End2", "rc1Stride"] rclass1
 


### PR DESCRIPTION
I know it is not that important.. but I think it should be fixed

This PR adds the following changes/**fixes**/enhancements:
- fixed typo in `line 59` 

...

# Checks

- [v] Did you run `ormolu`, a [Haskell Formatter](https://hackage.haskell.org/package/ormolu)? Run `ormolu --mode inplace $(git ls-files '*.hs')` to format all files in the project.
- [] Did you update `hie.yaml` using the command `gen-hie > hie.yaml`?
- [v] Do all tests pass using `stack test`?

